### PR TITLE
Add a serial communication interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,9 @@ repository = "https://github.com/japaric/mfrc522"
 version = "0.2.0"
 
 [dependencies]
-embedded-hal =  "0.2.0"
+embedded-hal = "0.2.0"
 generic-array = "0.11.0"
+nb = "0.1.2"
+
+[dev-dependencies]
+serial-embedded-hal = "0.1.2"

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -1,0 +1,58 @@
+//! Serial demo
+//!
+//! # Connections
+//!
+//! - 3V3 = VCC
+//! - TX = RX (SDA/NSS)
+//! - RX = TX (MISO/SCL)
+//! - RST = VCC
+//! - GND = GND
+
+extern crate serial_embedded_hal as hal;
+extern crate mfrc522;
+
+use hal::*;
+
+use mfrc522::Mfrc522;
+
+fn main() {
+    let port = std::env::args()
+        .skip(1)
+        .next()
+        .expect("please provide a serial port name as an argument");
+
+    let serial = Serial::new(&port, &PortSettings {
+        baud_rate: BaudRate::Baud9600,
+        char_size: CharSize::Bits8,
+        parity: Parity::ParityNone,
+        stop_bits: StopBits::Stop1,
+        flow_control: FlowControl::FlowNone,
+    }).expect("failed to open serial port");
+
+    let (tx, rx) = serial.split();
+
+    let mut mfrc522 = Mfrc522::new_serial(tx, rx).unwrap();
+
+    let vers = mfrc522.version().unwrap();
+
+    println!("VERSION: 0x{:x}", vers);
+
+    assert!(vers == 0x91 || vers == 0x92);
+
+    loop {
+        const CARD_UID: [u8; 4] = [34, 246, 178, 171];
+        const TAG_UID: [u8; 4] = [128, 170, 179, 76];
+
+        if let Ok(atqa) = mfrc522.reqa() {
+            if let Ok(uid) = mfrc522.select(&atqa) {
+                println!("UID: {:x?}", uid);
+
+                if uid.bytes() == &CARD_UID {
+                    println!("CARD");
+                } else if uid.bytes() == &TAG_UID {
+                    println!("TAG");
+                }
+            }
+        }
+    }
+}

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -1,0 +1,45 @@
+//! Communication interfaces for MFRC522
+
+use Register;
+
+/// SPI communication interface
+pub mod spi;
+
+pub use self::spi::SpiInterface;
+
+/// Trait for implementing a communication interface for MFRC522
+pub trait Mfrc522Interface {
+    /// Type of the error the interface may return.
+    type Error;
+
+    /// Reads multiple bytes from a register
+    fn read_many<'b>(&mut self, reg: Register, buffer: &'b mut [u8])
+        -> Result<&'b [u8], Self::Error>;
+
+    /// Writes multiple bytes from a register
+    fn write_many(&mut self, reg: Register, bytes: &[u8]) -> Result<(), Self::Error>;
+
+    /// Reads a single register
+    fn read(&mut self, reg: Register) -> Result<u8, Self::Error> {
+        let mut buffer = [0];
+
+        self.read_many(reg, &mut buffer)?;
+
+        Ok(buffer[0])
+    }
+
+    /// Writes a single register
+    fn write(&mut self, reg: Register, val: u8) -> Result<(), Self::Error> {
+        self.write_many(reg, &[val])
+    }
+
+    /// Performs a read-modify-write on a register
+    fn rmw<F>(&mut self, reg: Register, f: F) -> Result<(), Self::Error>
+    where
+        F: FnOnce(u8) -> u8,
+    {
+        let byte = self.read(reg)?;
+        self.write(reg, f(byte))?;
+        Ok(())
+    }
+}

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -5,7 +5,11 @@ use Register;
 /// SPI communication interface
 pub mod spi;
 
+/// Serial communication interface
+pub mod serial;
+
 pub use self::spi::SpiInterface;
+pub use self::serial::SerialInterface;
 
 /// Trait for implementing a communication interface for MFRC522
 pub trait Mfrc522Interface {

--- a/src/interface/serial.rs
+++ b/src/interface/serial.rs
@@ -1,0 +1,58 @@
+///! Serial communication interface for MFRC522
+
+use hal::serial::{Read, Write};
+use Register;
+use interface::Mfrc522Interface;
+
+/// SPI communication interface for MFRC522
+pub struct SerialInterface<W, R> {
+    write: W,
+    read: R,
+}
+
+impl<E, W, R> SerialInterface<W, R>
+where
+    W: Write<u8, Error = E>,
+    R: Read<u8, Error = E>,
+{
+    /// Default serial baud rate for MRFC522.
+    pub const BAUD_RATE: u32 = 9600;
+
+    /// Creates a interface using the provided serial read/write halves.
+    pub fn new(write: W, read: R) -> Self {
+        Self { write, read }
+    }
+}
+
+impl<E, W, R> Mfrc522Interface for SerialInterface<W, R>
+where
+    W: Write<u8, Error = E>,
+    R: Read<u8, Error = E>,
+{
+    type Error = E;
+
+    fn read_many<'b>(&mut self, reg: Register, buffer: &'b mut [u8])
+        -> Result<&'b [u8], Self::Error>
+    {
+        let addr = (reg as u8) | (1 << 7);
+
+        for slot in &mut buffer[..] {
+            block!(self.write.write(addr))?;
+            *slot = block!(self.read.read())?;
+        }
+
+        Ok(buffer)
+    }
+
+    fn write_many(&mut self, reg: Register, bytes: &[u8]) -> Result<(), Self::Error> {
+        let addr = reg as u8;
+
+        for &b in bytes {
+            block!(self.write.write(addr))?;
+            block!(self.write.write(b))?;
+            block!(self.read.read())?;
+        }
+
+        Ok(())
+    }
+}

--- a/src/interface/spi.rs
+++ b/src/interface/spi.rs
@@ -1,0 +1,80 @@
+#![allow(deprecated)] // FIXME: Remove when embedded-hal is updated
+
+///! SPI communication interface for MFRC522
+
+use hal::blocking::spi;
+use hal::spi::{Mode, Phase, Polarity};
+use hal::digital::OutputPin;
+use Register;
+use interface::Mfrc522Interface;
+
+/// SPI communication interface for MFRC522
+pub struct SpiInterface<SPI, NSS> {
+    spi: SPI,
+    nss: NSS,
+}
+
+impl<E, SPI, NSS> SpiInterface<SPI, NSS>
+where
+    SPI: spi::Transfer<u8, Error=E> + spi::Write<u8, Error=E>,
+    NSS: OutputPin,
+{
+    /// SPI mode. Pass to the platform SPI implementation to configure the bus correctly for
+    /// MFRC522.
+    pub const MODE: Mode = Mode {
+        polarity: Polarity::IdleLow,
+        phase: Phase::CaptureOnFirstTransition,
+    };
+
+    /// Creates a interface using the provided SPI peripheral and NSS pin.
+    pub fn new(spi: SPI, nss: NSS) -> Self {
+        Self { spi, nss }
+    }
+
+    fn with_nss_low<F, T>(&mut self, f: F) -> T
+    where
+        F: FnOnce(&mut Self) -> T,
+    {
+        self.nss.set_low();
+        let result = f(self);
+        self.nss.set_high();
+
+        result
+    }
+}
+
+impl<E, SPI, NSS> Mfrc522Interface for SpiInterface<SPI, NSS>
+where
+    SPI: spi::Transfer<u8, Error=E> + spi::Write<u8, Error=E>,
+    NSS: OutputPin,
+{
+    type Error = E;
+
+    fn read_many<'b>(&mut self, reg: Register, buffer: &'b mut [u8])
+        -> Result<&'b [u8], Self::Error>
+    {
+        let byte = reg.read_address();
+
+        self.with_nss_low(move |mfr| {
+            mfr.spi.transfer(&mut [byte])?;
+
+            let n = buffer.len();
+            for slot in &mut buffer[..n - 1] {
+                *slot = mfr.spi.transfer(&mut [byte])?[0];
+            }
+
+            buffer[n - 1] = mfr.spi.transfer(&mut [0])?[0];
+
+            Ok(&*buffer)
+        })
+    }
+
+    fn write_many(&mut self, reg: Register, bytes: &[u8]) -> Result<(), Self::Error> {
+        self.with_nss_low(|mfr| {
+            mfr.spi.write(&[reg.write_address()])?;
+            mfr.spi.write(bytes)?;
+
+            Ok(())
+        })
+    }
+}


### PR DESCRIPTION
MFRC522 supports I2C and serial UART besides just SPI, this adds support for the UART protocol.

On a microcontroller there probably isn't much advantage to using a UART over SPI, but this enables the module to be used on anything with a serial port or USB port with a USB to serial adapter. I included an example that should run on most computers. I'd like to add the anti-collision loop and support for the MIFARE stuff into this crate, and having a serial interface makes for a nicer development/debug cycle because I can run everything on a normal computer.

N.b. this currently changes API as I changed `Mfrc522::new` to take an interface object instead of just SPI. There are also helper methods `new_spi` and `new_serial` so that's it's equally nice to use.