### PR TITLE
Fix native Chip Select

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -374,8 +374,9 @@ where
 
     fn write_many(&mut self, reg: Register, bytes: &[u8]) -> Result<(), E> {
         self.with_nss_low(|mfr| {
-            mfr.spi.write(&[reg.write_address()])?;
-            mfr.spi.write(bytes)?;
+            for byte in bytes {
+                self.spi.write(&[reg.write_address(), *byte])?;
+            }
 
             Ok(())
         })


### PR DESCRIPTION
write_many sent the register and data in separate write calls, which triggered chip select twice, causing the first data byte to be interpreted as a register again.

I fixed this by sending each byte separately, which does introduce a slight overhead of (data_length - 1) bytes.
This could be reduced to 1 byte by transferring everything in one go, however this requires allocation to arrange the register byte and all data bytes for sending them in one go.
Of course, this being a no_std crate, introducing allocation seemed like a bit much for now.